### PR TITLE
Update ba.merge.sh

### DIFF
--- a/trunk/scripts/ba.merge.sh
+++ b/trunk/scripts/ba.merge.sh
@@ -101,7 +101,7 @@ then
 fi	
 
 cat ${outname}.vcf|$BEDTOOLS/sortBed -header|uniq |$TABIX/bgzip -c > ${outname}.vcf.gz
-BEGINNING=`grep -v "^#" ${outname}.vcf|wc -l`
+BEGINNING=`grep -v "^#" ${outname}.vcf|uniq|wc -l`
 FINAL=`zcat  ${outname}.vcf.gz|grep -v "^#"|wc -l`
 if [ $FINAL -lt $BEGINNING ]
 then


### PR DESCRIPTION
Uniq is not performed for the .vcf but it is done for .gz file. Later number of lines are checked to see if zipping went through. If there had been a duplicate variant and it got removed while creating the .gz file, the job hangs in error state.
